### PR TITLE
replicasets endpoint implemented

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,9 +84,9 @@ func (c ClusterConnection) GetReplicaSets(clusters []string, namespace string) (
 		replicaSets, err := c.connections[cluster].AppsV1().ReplicaSets(namespace).List(metav1.ListOptions{})
 		if err != nil {
 			errors = append(errors, err)
+		} else {
+			replicasetClusterMap[cluster] = replicaSets.Items
 		}
-
-		replicasetClusterMap[cluster] = replicaSets.Items
 	}
 
 	return replicasetClusterMap, errors
@@ -295,6 +295,7 @@ func GetReplicaSets(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
 
 	responseBytes, err := json.Marshal(replicaSets)
 	if err != nil {
+		fmt.Println(err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
this pr solve issue #13  .

#### What this PR does / why we need it:
This PR creates an endpoint on the router to handle `/resources/replicasets` endpoint to serve replicasets from specified clusters.

#### Special notes for your reviewer:
Implementation done such as `/resources/deployments` endpoint implementation to use same conventional pattern. One difference is that request URL takes namespace as parameter. If it does not exists, handler lists all replicasets on all namespaces.